### PR TITLE
Fix missing function declarations in mkeyb

### DIFF
--- a/sted2/mkeyb.c
+++ b/sted2/mkeyb.c
@@ -33,6 +33,9 @@ int     str_search();
 void	msg();
 void	msg_clr();
 void	snsclr();
+void	all_note_off();
+void	twait(int ti);
+int	str_search();
 
 /***************************/
 void	m_keyb(int ch,int bank,int prg,int velo)


### PR DESCRIPTION
## Summary
- declare missing functions in `mkeyb.c` to resolve implicit declaration errors

## Testing
- `make` *(fails: ja.po invalid multibyte sequence)*

------
https://chatgpt.com/codex/tasks/task_e_689f1705143c8332a23b0912b7fcd520