### PR TITLE
Fix missing function declarations in mkeyb and record

### DIFF
--- a/sted2/mkeyb.c
+++ b/sted2/mkeyb.c
@@ -33,6 +33,9 @@ int     str_search();
 void	msg();
 void	msg_clr();
 void	snsclr();
+void	all_note_off();
+void	twait(int ti);
+int	str_search();
 
 /***************************/
 void	m_keyb(int ch,int bank,int prg,int velo)

--- a/sted2/record.c
+++ b/sted2/record.c
@@ -68,6 +68,10 @@ int	rec_ext();
 int	meas_adjust();
 int	meas_adj_sub();
 
+int     add_set();
+int     dat_add();
+void    memcpy_l();
+
 /***************************/
 int	real_record()
 {


### PR DESCRIPTION
## Summary
- declare missing functions in `mkeyb.c` and `record.c` to resolve implicit declaration errors

## Testing
- `./configure`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_689f1705143c8332a23b0912b7fcd520