### PR TITLE
Fix missing function declarations in mkeyb, record, and rhythm editor

### DIFF
--- a/sted2/mkeyb.c
+++ b/sted2/mkeyb.c
@@ -33,6 +33,9 @@ int     str_search();
 void	msg();
 void	msg_clr();
 void	snsclr();
+void	all_note_off();
+void	twait(int ti);
+int	str_search();
 
 /***************************/
 void	m_keyb(int ch,int bank,int prg,int velo)

--- a/sted2/record.c
+++ b/sted2/record.c
@@ -68,6 +68,10 @@ int	rec_ext();
 int	meas_adjust();
 int	meas_adj_sub();
 
+int     add_set();
+int     dat_add();
+void    memcpy_l();
+
 /***************************/
 int	real_record()
 {

--- a/sted2/redit.c
+++ b/sted2/redit.c
@@ -8,7 +8,7 @@ static char	rym[10][3]={"- ","1 ","2 ","3 ","4 ","5 ","6 ","7 ","8 ","9 "};
 static char	rym_s[10][4]={"OFF"," 1 "," 2 "," 3 "," 4 "," 5 "," 6 "," 7 "," 8 "," 9 "};
 /*
 static char	rym0[10][3]={"- ","1 ","2 ","3 ","4 ","5 ","6 ","7 ","8 ","9 "};
-static char	rym1[10][3]={"๗ห","๗ฬ","๗อ","๗ฮ","๗ฯ","๗ะ","๗ั","๗า","๗ำ","๗ิ"};
+static char	rym1[10][3]={"รทร","รทร","รทร","รทร","รทร","รทร","รทร‘","รทร’","รทร“","รทร”"};
 static char	rym[10][3];
 */
 
@@ -39,7 +39,20 @@ void	cdplay();
 void	cntplay();
 void	trk_free();
 void	snsclr();
-void	twait();
+void        twait();
+
+void        edfield();
+void        trk_no();
+void        txxline();
+void        txyline();
+void        tcur();
+void        key_mouse_wait();
+void        cons_md();
+void        rhy_as();
+void        help();
+void        trk_lin();
+int add_set();
+void        sdis2();
 
 void	rtrk_ed();
 void	rtrk_dis();


### PR DESCRIPTION
## Summary
- declare missing functions in `mkeyb.c`, `record.c`, and `redit.c` to resolve implicit declaration errors

## Testing
- `./configure`
- `make -C sted2 redit.o`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_689f1705143c8332a23b0912b7fcd520