### PR TITLE
Clean translation template for gettext build

### DIFF
--- a/po/sted2.pot
+++ b/po/sted2.pot
@@ -607,7 +607,6 @@ msgstr ""
 msgid "         [DOWN]SELECTER  [ESC]CANCEL  [RET]SELECT"
 msgstr ""
 
-#. msg("ファイルがありません。");goto reinp;
 #: sted2/select.c:1040
 msgid "Directory not found."
 msgstr ""

--- a/sted2/visual.c
+++ b/sted2/visual.c
@@ -41,11 +41,20 @@ void	key_rep_on();
 int	key_shift();
 char	*ctrl_type();
 char	*prog_name();
+void	cons_md();
+void	sinput();
+int	spc_code();
+int	trk_check();
+void	line_ins_aft();
+void	edfield();
+int	step_cluc();
+
 
 void	txerase();
 void	txxline();
 void	txyline();
 void	g_print();
+void	g_print2();
 
 int	vinput();
 void	fnc_dis();
@@ -54,6 +63,7 @@ void	sdis();
 void	sdis2();
 void	vdis2();
 void	snsclr();
+void	memcpy_l();
 
 void	vis_disp();
 int	vis_bufset();


### PR DESCRIPTION
## Summary
- remove stray non-ASCII translator comment from `po/sted2.pot` to prevent charset errors during msgmerge

## Testing
- `./configure`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_689f45234b188332b3730811263809d5